### PR TITLE
Add BulkPicTools to Picture section - free bulk image processing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@
 - [pakutaso](https://www.pakutaso.com/) - 高解像度の画像を何枚でもダウンロードできる国内最大規模の写真素材サイトです
 - [isorepublic](https://isorepublic.com/) - Thousands of Free High-Resolution CC0 Photos and Videos
 - [The Met Collection](https://www.metmuseum.org/art/collection/) - The Met presents over 5,000 years of art from around the world for everyone to experience and enjoy.
+- [BulkPicTools](https://bulkpictools.com/) - Free browser-based bulk image processor. Compress, convert (HEIC/WebP/AVIF/PNG/JPG), resize, crop, watermark 1,000+ images at once. No upload, no account, works offline.
 
 ## Video
 


### PR DESCRIPTION
## What's being added

[BulkPicTools](https://bulkpictools.com/) - a free browser-based bulk image processing tool.

## Why it fits

The list already has image-related tools (TinyPNG API, ImageOptim API, PicView). BulkPicTools adds a practical, no-install option for bulk image processing:

- Compress, convert, resize, crop 1,000+ images at once — all in the browser
- Supports HEIC → JPG, PNG → WebP, AVIF, SVG and all major formats
- Files processed locally — nothing uploaded to any server
- 38 tools total: watermark, background removal, GIF creation, EXIF editing, and more
- Free, no account required, works offline as a PWA

Best placed in the Picture section, or alternatively under SaaS&Tools near PicView.